### PR TITLE
Error out on implied transaction commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 services: mysql
 


### PR DESCRIPTION
MySQL and MariaDB will automatically commit transactions on certain
commands such a `create table`, `alter table`, etc:
https://mariadb.com/kb/en/library/sql-statements-that-cause-an-implicit-commit/

It can be *very* confusing when that happens with this transaction
driver, so return an error when that happens.

This behaviour should probably be optional; since this is a MySQL driver
specific feature (e.g. PostgreSQL doesn't have this behaviour), but I'm
not sure what the best way is to pass the option? As a global variable,
or in the DSN, or something else?