### PR TITLE
Adds support for go modules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   # - 1.4 - mysql driver does not support
   # - 1.5.x - mysql driver does not support
   # - 1.6.x - mysql driver does not support
-  - 1.7.x
+  # - 1.7.x - mysql driver does not support
   - 1.8.x
   - 1.9.x
   - 1.10.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,15 @@ go:
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 services: mysql
 
 install:
   - go get github.com/go-sql-driver/mysql
+
+env:
+  - GO111MODULE=on
 
 script:
   - make db

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/data-dog/go-txdb
+
+require (
+	github.com/go-sql-driver/mysql v1.4.1
+	google.golang.org/appengine v1.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
+github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.3.0 h1:FBSsiFRMz3LBeXIomRnVzrQwSDj4ibvcRexLG0LZGQk=
+google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
This PR adds basic support fo [go modules](https://github.com/golang/go/wiki/Modules) by adding the required `go.mod` and `go.sum` files which were generated with the `go mod init && go mod tidy` commands.

Other Updates:
- TravisCI will opt-in to using modules using the `GO111MODULES` environment variable. (only affects Go 1.11.x)
- Removes Go 1.7 from TravisCI (go mysql no longer supports it)