### PR TITLE
test with mysql and postgres SQL drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 language: go
 go:
-  # - 1.3.x - mysql driver does not support
-  # - 1.4 - mysql driver does not support
-  # - 1.5.x - mysql driver does not support
-  # - 1.6.x - mysql driver does not support
-  - 1.7.x
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
-services: mysql
+services:
+  - mysql
+  - postgresql
 
 install:
   - go get github.com/go-sql-driver/mysql
+  - go get github.com/lib/pq
 
 script:
-  - make db
-  - go vet
   - test -z "$(go fmt ./...)" # fail if not formatted properly
-  - go test -race
+  - go vet
+  - make test # tests postgres and mysql databases

--- a/db_test.go
+++ b/db_test.go
@@ -3,169 +3,176 @@ package txdb
 import (
 	"database/sql"
 	"fmt"
-	"runtime"
+	"strings"
 	"sync"
 	"testing"
-
-	_ "github.com/go-sql-driver/mysql"
 )
 
-func init() {
-	// we register an sql driver txdb
-	Register("txdb", "mysql", "root@/txdb_test?multiStatements=true")
+func drivers() []string {
+	var all []string
+	for _, d := range sql.Drivers() {
+		if strings.Index(d, "_txdb") != -1 {
+			all = append(all, d)
+		}
+	}
+	return all
 }
 
 func TestShouldRunWithinTransaction(t *testing.T) {
 	t.Parallel()
-	var count int
-	db, err := sql.Open("txdb", "one")
-	if err != nil {
-		t.Fatalf("failed to open a mysql connection, have you run 'make test'? err: %s", err)
-	}
+	for _, driver := range drivers() {
+		var count int
+		db, err := sql.Open(driver, "one")
+		if err != nil {
+			t.Fatalf(driver+": failed to open a connection, have you run 'make test'? err: %s", err)
+		}
 
-	_, err = db.Exec(`INSERT INTO users(username, email) VALUES("txdb", "txdb@test.com")`)
-	if err != nil {
-		t.Fatalf("failed to insert an user: %s", err)
-	}
-	err = db.QueryRow("SELECT COUNT(id) FROM users").Scan(&count)
-	if err != nil {
-		t.Fatalf("failed to count users: %s", err)
-	}
-	if count != 4 {
-		t.Fatalf("expected 4 users to be in database, but got %d", count)
-	}
-	db.Close()
+		_, err = db.Exec(`INSERT INTO users (username, email) VALUES('txdb', 'txdb@test.com')`)
+		if err != nil {
+			t.Fatalf(driver+": failed to insert an user: %s", err)
+		}
+		err = db.QueryRow("SELECT COUNT(id) FROM users").Scan(&count)
+		if err != nil {
+			t.Fatalf(driver+": failed to count users: %s", err)
+		}
+		if count != 4 {
+			t.Fatalf(driver+": expected 4 users to be in database, but got %d", count)
+		}
+		db.Close()
 
-	db, err = sql.Open("txdb", "two")
-	if err != nil {
-		t.Fatalf("failed to reopen a mysql connection: %s", err)
-	}
+		db, err = sql.Open(driver, "two")
+		if err != nil {
+			t.Fatalf(driver+": failed to reopen a mysql connection: %s", err)
+		}
 
-	err = db.QueryRow("SELECT COUNT(id) FROM users").Scan(&count)
-	if err != nil {
-		t.Fatalf("failed to count users: %s", err)
+		err = db.QueryRow("SELECT COUNT(id) FROM users").Scan(&count)
+		if err != nil {
+			t.Fatalf(driver+": failed to count users: %s", err)
+		}
+		if count != 3 {
+			t.Fatalf(driver+": expected 3 users to be in database, but got %d", count)
+		}
+		db.Close()
 	}
-	if count != 3 {
-		t.Fatalf("expected 3 users to be in database, but got %d", count)
-	}
-	db.Close()
 }
 
 func TestShouldNotHoldConnectionForRows(t *testing.T) {
 	t.Parallel()
-	db, err := sql.Open("txdb", "three")
-	if err != nil {
-		t.Fatalf("failed to open a mysql connection, have you run 'make test'? err: %s", err)
-	}
-	defer db.Close()
+	for _, driver := range drivers() {
+		db, err := sql.Open(driver, "three")
+		if err != nil {
+			t.Fatalf(driver+": failed to open a connection, have you run 'make test'? err: %s", err)
+		}
+		defer db.Close()
 
-	rows, err := db.Query("SELECT username FROM users")
-	if err != nil {
-		t.Fatalf("failed to query users: %s", err)
-	}
-	defer rows.Close()
+		rows, err := db.Query("SELECT username FROM users")
+		if err != nil {
+			t.Fatalf(driver+": failed to query users: %s", err)
+		}
+		defer rows.Close()
 
-	_, err = db.Exec(`INSERT INTO users(username, email) VALUES("txdb", "txdb@test.com")`)
-	if err != nil {
-		t.Fatalf("failed to insert an user: %s", err)
+		_, err = db.Exec(`INSERT INTO users(username, email) VALUES('txdb', 'txdb@test.com')`)
+		if err != nil {
+			t.Fatalf(driver+": failed to insert an user: %s", err)
+		}
 	}
 }
 
 func TestShouldPerformParallelActions(t *testing.T) {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	t.Parallel()
-	db, err := sql.Open("txdb", "four")
-	if err != nil {
-		t.Fatalf("failed to open a mysql connection, have you run 'make test'? err: %s", err)
-	}
-	defer db.Close()
+	for _, driver := range drivers() {
+		db, err := sql.Open(driver, "four")
+		if err != nil {
+			t.Fatalf(driver+": failed to open a connection, have you run 'make test'? err: %s", err)
+		}
+		defer db.Close()
 
-	wg := &sync.WaitGroup{}
-	for i := 0; i < 4; i++ {
-		wg.Add(1)
-		go func(d *sql.DB, idx int) {
-			defer wg.Done()
-			rows, err := d.Query("SELECT username FROM users")
-			if err != nil {
-				t.Fatalf("failed to query users: %s", err)
-			}
-			defer rows.Close()
+		wg := &sync.WaitGroup{}
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func(d *sql.DB, idx int) {
+				defer wg.Done()
+				rows, err := d.Query("SELECT username FROM users")
+				if err != nil {
+					t.Fatalf(driver+": failed to query users: %s", err)
+				}
+				defer rows.Close()
 
-			username := fmt.Sprintf("parallel%d", idx)
-			email := fmt.Sprintf("parallel%d@test.com", idx)
-			_, err = d.Exec(`INSERT INTO users(username, email) VALUES(?, ?)`, username, email)
-			if err != nil {
-				t.Fatalf("failed to insert an user: %s", err)
-			}
-		}(db, i)
+				insertSQL := "INSERT INTO users(username, email) VALUES(?, ?)"
+				if strings.Index(driver, "psql_") == 0 {
+					insertSQL = "INSERT INTO users(username, email) VALUES($1, $2)"
+				}
+				username := fmt.Sprintf("parallel%d", idx)
+				email := fmt.Sprintf("parallel%d@test.com", idx)
+				_, err = d.Exec(insertSQL, username, email)
+				if err != nil {
+					t.Fatalf(driver+": failed to insert an user: %s", err)
+				}
+			}(db, i)
+		}
+		wg.Wait()
+		var count int
+		err = db.QueryRow("SELECT COUNT(id) FROM users").Scan(&count)
+		if err != nil {
+			t.Fatalf(driver+": failed to count users: %s", err)
+		}
+		if count != 7 {
+			t.Fatalf(driver+": expected 7 users to be in database, but got %d", count)
+		}
 	}
-	wg.Wait()
-	var count int
-	err = db.QueryRow("SELECT COUNT(id) FROM users").Scan(&count)
-	if err != nil {
-		t.Fatalf("failed to count users: %s", err)
-	}
-	if count != 7 {
-		t.Fatalf("expected 7 users to be in database, but got %d", count)
+}
+
+func TestShouldFailInvalidPrepareStatement(t *testing.T) {
+	t.Parallel()
+	for _, driver := range drivers() {
+		db, err := sql.Open(driver, "fail_prepare")
+		if err != nil {
+			t.Fatalf(driver+": failed to open a connection, have you run 'make test'? err: %s", err)
+		}
+		defer db.Close()
+
+		if _, err = db.Prepare("THIS SHOULD FAIL..."); err == nil {
+			t.Fatalf(driver + ": expected an error, since prepare should validate sql query, but got none")
+		}
 	}
 }
 
 func TestShouldHandlePrepare(t *testing.T) {
 	t.Parallel()
-	db, err := sql.Open("txdb", "five")
-	if err != nil {
-		t.Fatalf("failed to open a mysql connection, have you run 'make test'? err: %s", err)
-	}
-	defer db.Close()
+	for _, driver := range drivers() {
+		db, err := sql.Open(driver, "prepare")
+		if err != nil {
+			t.Fatalf(driver+": failed to open a connection, have you run 'make test'? err: %s", err)
+		}
+		defer db.Close()
 
-	if _, err = db.Prepare("THIS SHOULD FAIL..."); err == nil {
-		t.Fatalf("expected an error, since prepare should validate sql query, but got none")
-	}
+		selectSQL := "SELECT email FROM users WHERE username = ?"
+		if strings.Index(driver, "psql_") == 0 {
+			selectSQL = "SELECT email FROM users WHERE username = $1"
+		}
 
-	stmt1, err := db.Prepare("SELECT email FROM users WHERE username = ?")
-	if err != nil {
-		t.Fatalf("could not prepare - %s", err)
-	}
+		stmt1, err := db.Prepare(selectSQL)
+		if err != nil {
+			t.Fatalf(driver+": could not prepare - %s", err)
+		}
 
-	stmt2, err := db.Prepare("INSERT INTO users(username, email) VALUES(?, ?)")
-	if err != nil {
-		t.Fatalf("could not prepare - %s", err)
-	}
+		insertSQL := "INSERT INTO users (username, email) VALUES(?, ?)"
+		if strings.Index(driver, "psql_") == 0 {
+			insertSQL = "INSERT INTO users (username, email) VALUES($1, $2)"
+		}
+		stmt2, err := db.Prepare(insertSQL)
+		if err != nil {
+			t.Fatalf(driver+": could not prepare - %s", err)
+		}
 
-	var email string
-	if err = stmt1.QueryRow("jane").Scan(&email); err != nil {
-		t.Fatalf("could not scan email - %s", err)
-	}
+		var email string
+		if err = stmt1.QueryRow("jane").Scan(&email); err != nil {
+			t.Fatalf(driver+": could not scan email - %s", err)
+		}
 
-	_, err = stmt2.Exec("mark", "mark.spencer@gmail.com")
-	if err != nil {
-		t.Fatalf("should have inserted user - %s", err)
-	}
-}
-
-func TestShouldBeAbleToLockTables(t *testing.T) {
-	db, err := sql.Open("txdb", "locks")
-	if err != nil {
-		t.Fatalf("failed to open a mysql connection, have you run 'make test'? err: %s", err)
-	}
-	defer db.Close()
-
-	_, err = db.Exec("LOCK TABLES users READ")
-	if err != nil {
-		t.Fatalf("should be able to lock table, but got err: %v", err)
-	}
-
-	var count int
-	err = db.QueryRow("SELECT COUNT(*) FROM users").Scan(&count)
-	if err != nil {
-		t.Fatalf("unexpected read error: %v", err)
-	}
-	if count != 3 {
-		t.Fatalf("was expecting 3 users in db")
-	}
-
-	_, err = db.Exec("UNLOCK TABLES")
-	if err != nil {
-		t.Fatalf("should be able to unlock table, but got err: %v", err)
+		_, err = stmt2.Exec("mark", "mark.spencer@gmail.com")
+		if err != nil {
+			t.Fatalf(driver+": should have inserted user - %s", err)
+		}
 	}
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -1,0 +1,41 @@
+// +build mysql
+
+package txdb
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func init() {
+	Register("mysql_txdb", "mysql", "root@/txdb_test?multiStatements=true")
+}
+
+func TestShouldBeAbleToLockTables(t *testing.T) {
+	db, err := sql.Open("mysql_txdb", "locks")
+	if err != nil {
+		t.Fatalf("mysql: failed to open a mysql connection, have you run 'make test'? err: %s", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("LOCK TABLE users READ")
+	if err != nil {
+		t.Fatalf("mysql: should be able to lock table, but got err: %v", err)
+	}
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM users").Scan(&count)
+	if err != nil {
+		t.Fatalf("mysql: unexpected read error: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("mysql: was expecting 3 users in db")
+	}
+
+	_, err = db.Exec("UNLOCK TABLES")
+	if err != nil {
+		t.Fatalf("mysql: should be able to unlock table, but got err: %v", err)
+	}
+}

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -1,0 +1,9 @@
+// +build psql
+
+package txdb
+
+import _ "github.com/lib/pq"
+
+func init() {
+	Register("psql_txdb", "postgres", "postgres://postgres@localhost/txdb_test?sslmode=disable")
+}


### PR DESCRIPTION
should close #15 since `go test` would just test without any sql driver dependencies.
the code changes uses build tags to test **mysql** and **postgres** SQL driver support. Later **sqlite** may be added, just need to find an sqlite library supporting transactions.

should also close #16 and serve as a Postgres database example.