### PR TITLE
Support usage of sql.Out params within transaction

### DIFF
--- a/db_go19.go
+++ b/db_go19.go
@@ -1,0 +1,19 @@
+// +build go1.9
+
+package txdb
+
+import (
+	"database/sql"
+	"database/sql/driver"
+)
+
+
+// Implement the NamedValueChecker interface
+func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
+	switch nv.Value.(type) {
+	case sql.Out:
+		return nil
+	default:
+		return driver.ErrSkip
+	}
+}

--- a/db_go19.go
+++ b/db_go19.go
@@ -7,7 +7,6 @@ import (
 	"database/sql/driver"
 )
 
-
 // Implement the NamedValueChecker interface
 func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {


### PR DESCRIPTION
Updates the connection to implement the `NamedValueChecker` interface, with support for `sql.Out` named parameter types.  This will allow us to use `go-txdb` with stored procedures which contain output parameters