### PR TITLE
If Rollback fails, txdb keeps a bad connection in the pool

### DIFF
--- a/db.go
+++ b/db.go
@@ -181,10 +181,7 @@ func (c *conn) Close() (err error) {
 	c.opened--
 	if c.opened == 0 {
 		if c.tx != nil {
-			err = c.tx.Rollback()
-			if err != nil {
-				return
-			}
+			c.tx.Rollback()
 			c.tx = nil
 		}
 		c.drv.deleteConn(c.dsn)


### PR DESCRIPTION
Not sure this is entirely the best fix just yet, but fixes the problem for us.

We're seeing intermittent failure in our test suite when using txdb, if one test passes, and shuts down a query using a context - the next text often fails.

I believe this is because when `Close()` is called, the `Rollback` will `err` (with something like "context canceled").

Then when we try to open the DB (sql.Open) in the second test, it gets a stale connection and returns `driver: bad connection`. This change fixes the problem, but I'm not entirely sure why `sql.Open` will happily return a connection with a different DSN yet.