### PR TITLE
Add support for ScanType in ColumnType.

### DIFF
--- a/db.go
+++ b/db.go
@@ -57,6 +57,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 )
 
@@ -399,6 +400,10 @@ func (rs *rowSets) Columns() []string {
 
 func (rs *rowSets) ColumnTypeDatabaseTypeName(index int) string {
 	return rs.sets[rs.pos].ColumnTypeDatabaseTypeName(index)
+}
+
+func (rs *rowSets) ColumnTypeScanType(index int) reflect.Type {
+	return rs.sets[rs.pos].colTypes[index].ScanType()
 }
 
 func (rs *rowSets) Close() error {

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -2,8 +2,37 @@
 
 package txdb
 
-import _ "github.com/lib/pq"
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	_ "github.com/lib/pq"
+)
 
 func init() {
 	Register("psql_txdb", "postgres", "postgres://postgres@localhost/txdb_test?sslmode=disable")
+}
+
+func TestRowsScanTypeTables(t *testing.T) {
+	db, err := sql.Open("psql_txdb", "scantype")
+	if err != nil {
+		t.Fatalf("psql: failed to open a postgres connection, have you run 'make test'? err: %s", err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+	if err != nil {
+		t.Fatalf("psql: unable to execute trivial query: %v", err)
+	}
+
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		t.Fatalf("psql: unable to retrieve column types: %v", err)
+	}
+
+	int32Type := reflect.TypeOf(int32(0))
+	if colTypes[0].ScanType() != int32Type {
+		t.Fatalf("psql: column scan type is %s, but should be %s", colTypes[0].ScanType().String(), int32Type.String())
+	}
 }


### PR DESCRIPTION
The ColumnType.ScanType() function returns information about the type which is expected to be passed to the Rows.Scan() function for the corresponding column.  Without this commit go-txdb will claim everything should be an interface{} which, while not exactly wrong, is not particularly helpful.

I've also added a quick test to the PostgreSQL suite since that's where I'm thinking about using this library, but AFAIK this should also be effective for MySQL.