### PR TITLE
[nit] Set psql/mysql passwords to match Makefile, so `make test` works

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:alpine
     environment:
       POSTGRES_DB: txdb_test
-      POSTGRES_PASSWORD: ''
+      POSTGRES_PASSWORD: 'pass'
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - 5432:5432
@@ -14,6 +14,6 @@ services:
     image: mysql
     environment:
       MYSQL_DATABASE: txdb_test
-      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_ROOT_PASSWORD: pass
     ports:
       - 3306:3306


### PR DESCRIPTION
related: https://github.com/DATA-DOG/go-txdb/pull/51

To run tests on a local machine with Docker, the command below was originally working

```sh
$ docker compose up
$ make test
```

https://github.com/DATA-DOG/go-txdb/pull/51 set a password explicitly for mysql/psql in the Makefile, which made `make test` fail.

I went ahead and adjusted the docker-compose.yml so the password matches the Makefile. Now the tests pass locally.

```sh
$ make test
...
INSERT 0 3
Opening db...
Opening db...
PASS
ok  	github.com/DATA-DOG/go-txdb	0.626s
```