### PR TITLE
[nit] Migrate to docker compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ INSERTS := "INSERT INTO users (username, email) VALUES ('gopher', 'gopher@go.com
 
 MYSQLCMD=mysql
 ifndef CI
-	MYSQLCMD=docker-compose exec mysql mysql
+	MYSQLCMD=docker compose exec mysql mysql
 endif
 
 PSQLCMD=psql
 ifndef CI
-	PSQLCMD=docker-compose exec postgres psql
+	PSQLCMD=docker compose exec postgres psql
 endif
 
 test: mysql psql

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Every time you will run this application, it will remain in the same state as be
 
 Usage is mainly intended for testing purposes. See the **db_test.go** as
 an example. In order to run tests, you will need docker and
-docker-compose:
+docker compose:
 
-    docker-compose up
+    docker compose up
     make test
 
 The tests are currently using `postgres` and `mysql` databases


### PR DESCRIPTION
ref. https://docs.docker.com/compose/migrate/

When running the tests locally, I get messages like this.
```sh
$ make test
WARNING: Compose V1 is no longer supported and will be removed from Docker Desktop in an upcoming release. See https://docs.docker.com/go/compose-v1-eol/
mysql: [Warning] Using a password on the command line interface can be insecure.
WARNING: Compose V1 is no longer supported and will be removed from Docker Desktop in an upcoming release. See https://docs.docker.com/go/compose-v1-eol/
mysql: [Warning] Using a password on the command line interface can be insecure.
WARNING: Compose V1 is no longer supported and will be removed from Docker Desktop in an upcoming release. See https://docs.docker.com/go/compose-v1-eol/
mysql: [Warning] Using a password on the command line interface can be insecure.
WARNING: Compose V1 is no longer supported and will be removed from Docker Desktop in an upcoming release. See https://docs.docker.com/go/compose-v1-eol/
...
```

This is annoying, so I replaced `docker-compose` with `docker compose`. Now it is a lot simpler. This docker-compose file is only used for testing purposes so should not have any affect to users using go-txdb.

```sh
$ make test
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
DROP DATABASE
CREATE DATABASE
CREATE TABLE
INSERT 0 3
Opening db...
Opening db...
[nit] migrate to docker compose v2
PASS
ok  	github.com/DATA-DOG/go-txdb	0.439s
```