### PR TITLE
don't cancel tx when stmt failed

### DIFF
--- a/db_go18.go
+++ b/db_go18.go
@@ -1,4 +1,4 @@
-// +build go1.8
+//go:build go1.8
 
 package txdb
 
@@ -131,7 +131,7 @@ func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 		case <-c.ctx.Done():
 		case erred := <-stmtFailedStr:
 			if erred {
-				c.cancel()
+				st.Close()
 			}
 		}
 	}()


### PR DESCRIPTION
This is releated to https://github.com/DATA-DOG/go-txdb/issues/49, when stmt execute failed, the root tx is also cancelled, so `Rollback/Close` can't use the root tx any more.