### PR TITLE
Implement the Close() method on our connector

### DIFF
--- a/db.go
+++ b/db.go
@@ -161,6 +161,17 @@ func (c *txConnector) Driver() driver.Driver {
 	return c.driver
 }
 
+// Close is called when [database/sql.DB.Close] is called, and the Close method
+// on any opened connections.
+func (c *txConnector) Close() error {
+	for _, conn := range c.driver.conns {
+		if err := conn.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (d *TxDriver) DB() *sql.DB {
 	return d.db
 }


### PR DESCRIPTION
This allows a call to `db.Close()` to be effective at closing the underlying connections.

This avoids a deadlock with one of my clients, when creating a new DB and closing it for each test.  It may not be the best solution, or may need some additional consideration. All feedback welcome.